### PR TITLE
Fix error with misplaced parentheses

### DIFF
--- a/rich_text_renderer/block_renderers.py
+++ b/rich_text_renderer/block_renderers.py
@@ -115,10 +115,10 @@ class AssetHyperlinkRenderer(BaseBlockRenderer):
             return self._render_asset(asset, node)
         elif isinstance(asset, dict):
             if "fields" not in asset and "file" not in asset.get("fields", {}):
-                raise Exception("Node target is not an asset - Node: {0}").format(node)
+                raise Exception("Node target is not an asset - Node: {0}".format(node))
             return self._render_hash(asset, node)
         else:
-            raise Exception("Node target is not an asset - Node: {0}").format(node)
+            raise Exception("Node target is not an asset - Node: {0}".format(node))
 
     def _render_asset(self, asset, node=None):
         return self._render(

--- a/tests/block_renderers_test.py
+++ b/tests/block_renderers_test.py
@@ -302,16 +302,6 @@ class AssetBlockRendererTest(TestCase):
             '<a href="https://example.com/cat.csv">Foo</a>',
         )
 
-    def test_render_raises_exception_when_node_is_not_asset(self):
-        with self.assertRaises(Exception):
-            AssetHyperlinkRenderer().render(mock_node)
-
-        with self.assertRaises(Exception):
-            AssetHyperlinkRenderer().render({"data": {"target": None}})
-
-        with self.assertRaises(Exception):
-            AssetHyperlinkRenderer().render({"data": {"target": {}}})
-
 
 class AssetHyperlinkRendererTest(TestCase):
     def test_render(self):
@@ -321,3 +311,18 @@ class AssetHyperlinkRendererTest(TestCase):
             ),
             '<a href="https://example.com/cat.jpg">Example</a>',
         )
+
+    def test_render_raises_exception_when_node_is_not_asset(self):
+        with self.assertRaises(Exception) as cm:
+            AssetHyperlinkRenderer().render(mock_node)
+        self.assertEquals(cm.exception.__class__, KeyError)
+
+        with self.assertRaises(Exception) as cm:
+            AssetHyperlinkRenderer().render({"data": {"target": None}})
+        self.assertEquals(cm.exception.__class__, Exception)
+        self.assertRegex(str(cm.exception), r"^Node target is not an asset")
+
+        with self.assertRaises(Exception) as cm:
+            AssetHyperlinkRenderer().render({"data": {"target": {}}})
+        self.assertEquals(cm.exception.__class__, Exception)
+        self.assertRegex(str(cm.exception), r"^Node target is not an asset")


### PR DESCRIPTION
For Exceptions thrown in the AssetHyperlinkRenderer#render method.
Might not need the tests, please discard them if you don't need them.